### PR TITLE
Add Carpalx, Colemak-DH ANSI, and Colemak-DH Orth layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Add Carpalx, Colemak-DH ANSI, and Colemak-DH Orth layout.
+
 ## [v2.0.0] - 2024-02-17
 
 ### Added

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -24,6 +24,13 @@ const gchar *kbType_ids[] = {N_("default"),
                              N_("thl_pinying"),
                              N_("mps2_pinyin"),
 #endif
+#if CHEWING_CHECK_VERSION(0, 5, 0)
+                             N_("carpalx"),
+#endif
+#if CHEWING_CHECK_VERSION(0, 6, 0)
+                             N_("colemak_dh_ansi"),
+                             N_("colemak_dh_orth"),
+#endif
                              NULL};
 
 #define SELKEYS_ARRAY_SIZE 8

--- a/src/IBusChewingUtil.h
+++ b/src/IBusChewingUtil.h
@@ -62,6 +62,15 @@ typedef enum {
     CHEWING_KBTYPE_LUOMA_PINYIN,
     CHEWING_KBTYPE_MSP2
 #endif
+#if CHEWING_CHECK_VERSION(0, 5, 0)
+    ,
+    CHEWING_KBTYPE_CARPALX
+#endif
+#if CHEWING_CHECK_VERSION(0, 3, 4)
+    ,
+    CHEWING_KBTYPE_COLEMAK_DH_ANSI,
+    CHEWING_KBTYPE_COLEMAK_DH_ORTH
+#endif
 } ChewingKbType;
 
 KSym key_sym_KP_to_normal(KSym k);

--- a/src/setup/ibus-setup-chewing-window.c
+++ b/src/setup/ibus-setup-chewing-window.c
@@ -76,9 +76,23 @@ ibus_setup_chewing_window_class_init(IbusSetupChewingWindowClass *klass) {
 }
 
 const gchar *kb_type_ids[] = {
-    "default",     "hsu",         "ibm",        "gin_yieh",  "eten",
-    "eten26",      "dvorak",      "dvorak_hsu", "dachen_26", "hanyu",
-    "thl_pinying", "mps2_pinyin", NULL};
+    "default",
+    "hsu",
+    "ibm",
+    "gin_yieh",
+    "eten",
+    "eten26",
+    "dvorak",
+    "dvorak_hsu",
+    "dachen_26",
+    "hanyu",
+    "thl_pinying",
+    "mps2_pinyin",
+    "carpalx",
+    "colemak_dh_ansi",
+    "colemak_dh_orth",
+    NULL,
+};
 
 const gchar *sel_key_ids[] = {
     "1234567890", "asdfghjkl;", "asdfzxcv89",

--- a/src/setup/ibus-setup-chewing-window.ui
+++ b/src/setup/ibus-setup-chewing-window.ui
@@ -29,6 +29,9 @@
                       <item translatable="yes">Hanyu Pinyin</item>
                       <item translatable="yes">THL Pinyin</item>
                       <item translatable="yes">MPS2 Pinyin</item>
+                      <item translatable="yes">Carpalx</item>
+                      <item translatable="yes">Colemak-DH ANSI</item>
+                      <item translatable="yes">Colemak-DH Ortholinear</item>
                     </items>
                   </object>
                 </property>


### PR DESCRIPTION
Add new layouts in `ibus-setup-chewing`, including:

* Carpalx
* Colemak-DH ANSI
* Colemak-DH Ortholinear
