### PR TITLE
refactor: Clear pre-edit buffer before commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Carpalx, Colemak-DH ANSI, and Colemak-DH Orth layout.
 
+### Changed
+
+- Clear pre-edit buffer before commit it to engine to avoid showing both buffer
+  on the screen.
+
 ## [v2.0.0] - 2024-02-17
 
 ### Added

--- a/src/ibus-chewing-engine.c
+++ b/src/ibus-chewing-engine.c
@@ -410,8 +410,8 @@ void ibus_chewing_engine_update(IBusChewingEngine *self) {
     g_return_if_fail(IBUS_IS_CHEWING_ENGINE(self));
     {
         IBUS_CHEWING_LOG(DEBUG, "update() statusFlags=%x", selfp->statusFlags);
-        commit_text(self);
         update_pre_edit_text(self);
+        commit_text(self);
         update_aux_text(self);
 
         IBUS_CHEWING_LOG(DEBUG, "update() nPhoneSeq=%d statusFlags=%x",


### PR DESCRIPTION
To avoid showing both the committed string and pre-edit buffer at the same time.