### PR TITLE
fix: fix ignored selection key setting when candidate per page is less than 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix ignored selection key setting when candidate per page is less than 10.
+
 ## [v2.1.3] - 2025-01-01
 
 ### Fixed

--- a/src/IBusChewingLookupTable.c
+++ b/src/IBusChewingLookupTable.c
@@ -38,7 +38,7 @@ void ibus_chewing_lookup_table_resize(IBusLookupTable *iTable, ChewingContext *c
         }
     }
     chewing_set_candPerPage(context, len);
-    chewing_set_selKey(context, selKSym, len);
+    chewing_set_selKey(context, selKSym, MAX_SELKEY);
 
     gboolean verticalLookupTable = g_settings_get_boolean(settings, "vertical-lookup-table");
 


### PR DESCRIPTION
libchewing API document says

> selkeys is an ASCII code integer array of length [MAX_SELKEY](https://docs.rs/chewing_capi/latest/chewing_capi/candidates/constant.MAX_SELKEY.html). The second argument is unused.

However, it actually resets the selkey to default if any length that is not 10 is passed. Fixing the API is more dangerous because we might accidentally read pass end of array passed in. So fixing in ibus-chewing instead.
