### PR TITLE
Fix: Ensure Ctrl+Space Is Passed to IBus Correctly, Not Absorbed

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -450,7 +450,7 @@ EventResponse self_handle_page_down(IBusChewingPreEdit *self, KSym kSym, KeyModi
 }
 
 EventResponse self_handle_space(IBusChewingPreEdit *self, KSym kSym, KeyModifiers unmaskedMod) {
-    filter_modifiers(IBUS_SHIFT_MASK | IBUS_CONTROL_MASK);
+    filter_modifiers(IBUS_SHIFT_MASK);
 
     if (!is_shift_only && !is_chinese && !is_full_shape) {
         /* Let libchewing handles Keypad keys only when needed.


### PR DESCRIPTION
On GNOME 46 (and maybe earlier versions) with Wayland, the Ctrl+Space key event somehow cannot be passed to IBus correctly, which prevents users from switching input methods with that shortcut. 

As this event does not need to be handled by libchewing, we simply remove Ctrl from the modifiers for the self_handle_space function. This will ensure the event is always passed to IBus.

This should fix issue #253.